### PR TITLE
Use rich type systems in api/mm/spci.

### DIFF
--- a/hfo2/src/abi.rs
+++ b/hfo2/src/abi.rs
@@ -29,9 +29,9 @@ pub enum HfVCpuRunReturn {
 
     /// The vCPU is blocked waiting for an interrupt. The scheduler MUST take
     /// it off the run queue and not call `hf_vcpu_run` on the vCPU until it
-    /// has injected an interrupt, received `HfVCpuRunReturn::WakeUp` for it 
+    /// has injected an interrupt, received `HfVCpuRunReturn::WakeUp` for it
     /// from another vCPU or the timeout provided in `ns` is not
-    ///  `HF_SLEEP_INDEFINITE` and the specified duration has expired.
+    /// `HF_SLEEP_INDEFINITE` and the specified duration has expired.
     WaitForInterrupt { ns: u64 },
 
     /// The vCPU is blocked waiting for a message. The scheduler MUST take it
@@ -47,7 +47,10 @@ pub enum HfVCpuRunReturn {
     /// the vCPU in question up if it is blocked, or preempt and re-run it if
     /// it is already running somewhere. This gives Hafnium a chance to update
     /// any CPU state which might have changed.
-    WakeUp { vm_id: spci_vm_id_t, vcpu: spci_vcpu_index_t },
+    WakeUp {
+        vm_id: spci_vm_id_t,
+        vcpu: spci_vcpu_index_t,
+    },
 
     /// A message has been sent by the vCPU. The scheduler MUST run a vCPU from
     /// the recipient VM and priority SHOULD be given to those vCPUs that are
@@ -90,8 +93,7 @@ pub unsafe extern "C" fn hf_vcpu_run_return_encode(res: HfVCpuRunReturn) -> u64 
         Yield => 1,
         WaitForInterrupt { ns } => 2 | (ns << 8),
         WaitForMessage { ns } => 3 | (ns << 8),
-        WakeUp { vm_id, vcpu } =>
-            4 | ((vm_id as u64) << 32) | ((vcpu as u64) << 16),
+        WakeUp { vm_id, vcpu } => 4 | ((vm_id as u64) << 32) | ((vcpu as u64) << 16),
         Message { vm_id } => 5 | ((vm_id as u64) << 8),
         NotifyWaiters => 6,
         Aborted => 7,

--- a/hfo2/src/abi.rs
+++ b/hfo2/src/abi.rs
@@ -83,19 +83,20 @@ pub enum HfShare {
     Share,
 }
 
-/// Encode an HfVCpuRunReturn struct in the 64-bit packing ABI.
-#[inline]
-pub unsafe extern "C" fn hf_vcpu_run_return_encode(res: HfVCpuRunReturn) -> u64 {
-    use HfVCpuRunReturn::*;
+impl HfVCpuRunReturn {
+    /// Encode an HfVCpuRunReturn struct in the 64-bit packing ABI.
+    pub fn into_raw(self) -> u64 {
+        use HfVCpuRunReturn::*;
 
-    match res {
-        Preempted => 0,
-        Yield => 1,
-        WaitForInterrupt { ns } => 2 | (ns << 8),
-        WaitForMessage { ns } => 3 | (ns << 8),
-        WakeUp { vm_id, vcpu } => 4 | ((vm_id as u64) << 32) | ((vcpu as u64) << 16),
-        Message { vm_id } => 5 | ((vm_id as u64) << 8),
-        NotifyWaiters => 6,
-        Aborted => 7,
+        match self {
+            Preempted => 0,
+            Yield => 1,
+            WaitForInterrupt { ns } => 2 | (ns << 8),
+            WaitForMessage { ns } => 3 | (ns << 8),
+            WakeUp { vm_id, vcpu } => 4 | ((vm_id as u64) << 32) | ((vcpu as u64) << 16),
+            Message { vm_id } => 5 | ((vm_id as u64) << 8),
+            NotifyWaiters => 6,
+            Aborted => 7,
+        }
     }
 }

--- a/hfo2/src/addr.rs
+++ b/hfo2/src/addr.rs
@@ -68,85 +68,85 @@ impl fmt::Display for vaddr_t {
 
 /// Initializes a physical address.
 #[inline]
-pub fn pa_init(p: uintpaddr_t) -> paddr_t {
+pub const fn pa_init(p: uintpaddr_t) -> paddr_t {
     paddr_t { pa: p }
 }
 
 /// Extracts the absolute physical address.
 #[inline]
-pub fn pa_addr(pa: paddr_t) -> uintpaddr_t {
+pub const fn pa_addr(pa: paddr_t) -> uintpaddr_t {
     pa.pa
 }
 
 /// Advances a physical address.
 #[inline]
-pub fn pa_add(pa: paddr_t, n: size_t) -> paddr_t {
+pub const fn pa_add(pa: paddr_t, n: size_t) -> paddr_t {
     pa_init(pa_addr(pa) + n)
 }
 
 /// Returns the difference between two physical addresses.
 #[inline]
-pub fn pa_difference(start: paddr_t, end: paddr_t) -> size_t {
+pub const fn pa_difference(start: paddr_t, end: paddr_t) -> size_t {
     pa_addr(end) - pa_addr(start)
 }
 
 /// Initializes an intermediate physical address.
 #[inline]
-pub fn ipa_init(ipa: uintpaddr_t) -> ipaddr_t {
+pub const fn ipa_init(ipa: uintpaddr_t) -> ipaddr_t {
     ipaddr_t { ipa: ipa }
 }
 
 /// Extracts the absolute intermediate physical address.
 #[inline]
-pub fn ipa_addr(ipa: ipaddr_t) -> uintpaddr_t {
+pub const fn ipa_addr(ipa: ipaddr_t) -> uintpaddr_t {
     ipa.ipa
 }
 
 /// Advances an intermediate physical address.
 #[inline]
-pub fn ipa_add(ipa: ipaddr_t, n: size_t) -> ipaddr_t {
+pub const fn ipa_add(ipa: ipaddr_t, n: size_t) -> ipaddr_t {
     ipa_init(ipa_addr(ipa) + n)
 }
 
 /// Initializes a virtual address.
 #[inline]
-pub fn va_init(v: uintvaddr_t) -> vaddr_t {
+pub const fn va_init(v: uintvaddr_t) -> vaddr_t {
     vaddr_t { va: v }
 }
 
 /// Extracts the absolute virtual address.
 #[inline]
-pub fn va_addr(va: vaddr_t) -> uintvaddr_t {
+pub const fn va_addr(va: vaddr_t) -> uintvaddr_t {
     va.va
 }
 
 /// Casts a physical address to a virtual address.
 #[inline]
-pub fn va_from_pa(pa: paddr_t) -> vaddr_t {
+pub const fn va_from_pa(pa: paddr_t) -> vaddr_t {
     va_init(pa_addr(pa))
 }
 
 /// Casts a physical address to an intermediate physical address.
 #[inline]
-pub fn ipa_from_pa(pa: paddr_t) -> ipaddr_t {
+pub const fn ipa_from_pa(pa: paddr_t) -> ipaddr_t {
     ipa_init(pa_addr(pa))
 }
 
 /// Casts a virtual address to a physical address.
 #[inline]
-pub fn pa_from_va(va: vaddr_t) -> paddr_t {
+pub const fn pa_from_va(va: vaddr_t) -> paddr_t {
     pa_init(va_addr(va))
 }
 
 /// Casts an intermediate physical address to a physical address.
 #[inline]
-pub fn pa_from_ipa(ipa: ipaddr_t) -> paddr_t {
+pub const fn pa_from_ipa(ipa: ipaddr_t) -> paddr_t {
     pa_init(ipa_addr(ipa))
 }
 
 /// Casts a pointer to a virtual address.
 #[inline]
-pub fn va_from_ptr(p: *const c_void) -> vaddr_t {
+pub const unsafe fn va_from_ptr(p: *const c_void) -> vaddr_t {
     vaddr_t {
         va: p as uintvaddr_t,
     }
@@ -156,6 +156,6 @@ pub fn va_from_ptr(p: *const c_void) -> vaddr_t {
 /// mapped for the calling context.
 /// TODO: check the mapping for a range and return a memiter?
 #[inline]
-pub fn ptr_from_va(va: vaddr_t) -> *mut c_void {
+pub const fn ptr_from_va(va: vaddr_t) -> *mut c_void {
     va_addr(va) as *mut c_void
 }

--- a/hfo2/src/api.rs
+++ b/hfo2/src/api.rs
@@ -602,7 +602,7 @@ unsafe fn api_vm_configure_stage1(
         mm_stage1_locked,
         pa_send_begin,
         pa_send_end,
-        Mode::R.bits() as i32,
+        Mode::R,
         local_page_pool,
     ) as usize as *const SpciMessage;
     if (*vm_locked.vm).mailbox.send == ptr::null() {
@@ -623,7 +623,7 @@ unsafe fn api_vm_configure_stage1(
         mm_stage1_locked,
         pa_recv_begin,
         pa_recv_end,
-        Mode::W.bits() as i32,
+        Mode::W,
         local_page_pool,
     ) as usize as *mut SpciMessage;
     if (*vm_locked.vm).mailbox.recv == ptr::null_mut() {
@@ -1414,7 +1414,7 @@ unsafe fn api_clear_memory(begin: paddr_t, end: paddr_t, ppool: *mut MPool) -> b
     // TODO: Refactor result variable name.
     // But mm_identity_map returns begin if succeed or null pointer otherwise.
     // Hence the name is not important.
-    let ptr_ = mm_identity_map(stage1_locked, begin, end, Mode::W.bits() as i32, ppool);
+    let ptr_ = mm_identity_map(stage1_locked, begin, end, Mode::W, ppool);
     let size = pa_difference(begin, end);
 
     if ptr_ == ptr::null_mut() {

--- a/hfo2/src/api.rs
+++ b/hfo2/src/api.rs
@@ -109,9 +109,8 @@ pub unsafe extern "C" fn api_preempt(current: *mut VCpu) -> *mut VCpu {
 #[no_mangle]
 pub unsafe extern "C" fn api_wait_for_interrupt(current: *mut VCpu) -> *mut VCpu {
     let ret = HfVCpuRunReturn::WaitForInterrupt {
-        // TODO: `api_switch_to_primary` always initialize this variable,
-        // but it would be better if we don't use `mem::uninitialized()`.
-        ns: mem::uninitialized(),
+        // `api_switch_to_primary` always initializes this variable.
+        ns: HF_SLEEP_INDEFINITE,
     };
 
     api_switch_to_primary(current, ret, VCpuStatus::BlockedInterrupt)
@@ -121,9 +120,8 @@ pub unsafe extern "C" fn api_wait_for_interrupt(current: *mut VCpu) -> *mut VCpu
 #[no_mangle]
 pub unsafe extern "C" fn api_vcpu_off(current: *mut VCpu) -> *mut VCpu {
     let ret = HfVCpuRunReturn::WaitForInterrupt {
-        // TODO: `api_switch_to_primary` always initialize this variable,
-        // but it would be better if we don't use `mem::uninitialized()`.
-        ns: mem::uninitialized(),
+        // `api_switch_to_primary` always initializes this variable.
+        ns: HF_SLEEP_INDEFINITE,
     };
 
     // Disable the timer, so the scheduler doesn't get told to call back
@@ -1156,9 +1154,8 @@ pub unsafe extern "C" fn api_spci_msg_recv(
     // Switch back to primary vm to block.
     {
         let run_return = HfVCpuRunReturn::WaitForMessage {
-            // TODO: `api_switch_to_primary` always initialize this variable,
-            // but it would be better if we don't use `mem::uninitialized()`.
-            ns: mem::uninitialized(),
+            // `api_switch_to_primary` always initializes this variable.
+            ns: HF_SLEEP_INDEFINITE,
         };
 
         *next = api_switch_to_primary(current, run_return, VCpuStatus::BlockedMailbox);

--- a/hfo2/src/arch/aarch64.rs
+++ b/hfo2/src/arch/aarch64.rs
@@ -35,6 +35,9 @@ pub type uintpaddr_t = uintptr_t;
 /// Integer type large enough to hold a virtual address.
 pub type uintvaddr_t = uintptr_t;
 
+/// The type of a page table entry (PTE).
+pub type pte_t = u64;
+
 /// The struct for storing a floating point register.
 ///
 /// 2 64-bit integers used to avoid need for FP support at this level.

--- a/hfo2/src/arch/fake.rs
+++ b/hfo2/src/arch/fake.rs
@@ -31,6 +31,9 @@ pub type uintpaddr_t = uintptr_t;
 /// Integer type large enough to hold a virtual address.
 pub type uintvaddr_t = uintptr_t;
 
+/// The type of a page table entry (PTE).
+pub type pte_t = u64;
+
 /// Arch-specific information about a VM.
 #[repr(C)]
 pub struct ArchVm {

--- a/hfo2/src/cpu.rs
+++ b/hfo2/src/cpu.rs
@@ -88,10 +88,10 @@ pub enum VCpuStatus {
 #[repr(C)]
 pub struct Interrupts {
     /// Bitfield keeping track of which interrupts are enabled.
-    pub enabled: [u32; HF_NUM_INTIDS / INTERRUPT_REGISTER_BITS],
+    pub enabled: [u32; HF_NUM_INTIDS as usize / INTERRUPT_REGISTER_BITS],
 
     /// Bitfield keeping track of which interrupts are pending.
-    pub pending: [u32; HF_NUM_INTIDS / INTERRUPT_REGISTER_BITS],
+    pub pending: [u32; HF_NUM_INTIDS as usize / INTERRUPT_REGISTER_BITS],
 
     /// The number of interrupts which are currently both enabled and pending. i.e. the number of
     /// bits set in enabled & pending.

--- a/hfo2/src/cpu.rs
+++ b/hfo2/src/cpu.rs
@@ -103,7 +103,7 @@ pub struct VCpuFaultInfo {
     ipaddr: ipaddr_t,
     vaddr: vaddr_t,
     pc: vaddr_t,
-    mode: c_int,
+    mode: Mode,
 }
 
 #[repr(C)]
@@ -379,7 +379,7 @@ pub unsafe extern "C" fn vcpu_handle_page_fault(
 ) -> bool {
     let vm = (*current).vm;
     let mut mode = mem::uninitialized(); // to avoid use-of-uninitialized error
-    let mask = (*f).mode | Mode::INVALID.bits() as i32;
+    let mask = (*f).mode | Mode::INVALID;
     let resume;
 
     sl_lock(&(*vm).lock);
@@ -409,7 +409,7 @@ pub unsafe extern "C" fn vcpu_handle_page_fault(
             vcpu_index(current),
             (*f).vaddr,
             (*f).ipaddr,
-            (*f).mode
+            (*f).mode.bits() as u32
         );
     }
 

--- a/hfo2/src/cpu.rs
+++ b/hfo2/src/cpu.rs
@@ -358,7 +358,7 @@ pub unsafe extern "C" fn vcpu_secondary_reset_and_start(
             false,
             (*vm).id,
             vcpu_index(vcpu) as cpu_id_t,
-            pa_init((*vm).ptable.root),
+            (*vm).ptable.root,
         );
         vcpu_on(vcpu_locked, entry, arg);
     }

--- a/hfo2/src/mm.rs
+++ b/hfo2/src/mm.rs
@@ -1103,10 +1103,9 @@ pub unsafe extern "C" fn mm_identity_map(
     mut stage1_locked: mm_stage1_locked,
     begin: paddr_t,
     end: paddr_t,
-    mode: c_int,
+    mode: Mode,
     mpool: *const MPool,
 ) -> *mut usize {
-    let mode = Mode::from_bits_truncate(mode as u32);
     let mpool = &*mpool;
     stage1_locked
         .identity_map(pa_addr(begin), pa_addr(end), mode, mpool)

--- a/hfo2/src/mm.rs
+++ b/hfo2/src/mm.rs
@@ -1015,12 +1015,11 @@ pub unsafe extern "C" fn mm_vm_identity_map(
     t: *mut PageTable<Stage2>,
     begin: paddr_t,
     end: paddr_t,
-    mode: c_int,
+    mode: Mode,
     ipa: *mut usize,
     mpool: *const MPool,
 ) -> bool {
     let t = &mut *t;
-    let mode = Mode::from_bits_truncate(mode as u32);
     let mpool = &*mpool;
     t.identity_map(pa_addr(begin), pa_addr(end), mode, mpool)
         .map(|_| {
@@ -1091,11 +1090,11 @@ pub unsafe extern "C" fn mm_vm_get_mode(
     t: *mut PageTable<Stage2>,
     begin: ipaddr_t,
     end: ipaddr_t,
-    mode: *mut c_int,
+    mode: *mut Mode,
 ) -> bool {
     let t = &mut *t;
     t.get_mode(ipa_addr(begin), ipa_addr(end))
-        .map(|m| *mode = m.bits as c_int)
+        .map(|m| *mode = m)
         .is_some()
 }
 

--- a/hfo2/src/spci.rs
+++ b/hfo2/src/spci.rs
@@ -18,9 +18,9 @@ use core::marker::PhantomData;
 use core::mem;
 
 use crate::addr::*;
+use crate::mm::*;
 use crate::types::*;
 use crate::vm::*;
-use crate::mm::*;
 
 pub const SPCI_VERSION_MAJOR: i32 = 0x0;
 pub const SPCI_VERSION_MINOR: i32 = 0x9;

--- a/hfo2/src/spci.rs
+++ b/hfo2/src/spci.rs
@@ -20,6 +20,7 @@ use core::mem;
 use crate::addr::*;
 use crate::types::*;
 use crate::vm::*;
+use crate::mm::*;
 
 pub const SPCI_VERSION_MAJOR: i32 = 0x0;
 pub const SPCI_VERSION_MINOR: i32 = 0x9;
@@ -88,12 +89,12 @@ extern "C" {
         to: *mut Vm,
         from: *mut Vm,
         share: SpciMemoryShare,
-        orig_from_mode: *mut c_int,
+        orig_from_mode: *mut Mode,
         begin: ipaddr_t,
         end: ipaddr_t,
         memory_to_attributes: u32,
-        from_mode: *mut c_int,
-        to_mode: *mut c_int,
+        from_mode: *mut Mode,
+        to_mode: *mut Mode,
     ) -> bool;
 }
 

--- a/hfo2/src/spci.rs
+++ b/hfo2/src/spci.rs
@@ -47,15 +47,29 @@ pub enum SpciMemoryShare {
 }
 
 // SPCI function specific constants.
-pub const SPCI_MSG_RECV_BLOCK_MASK: u32 = 0x1;
-pub const SPCI_MSG_SEND_NOTIFY_MASK: u32 = 0x1;
+bitflags! {
+    /// For SpciMessage::flags
+    /// flags[15:1] reserved(MBZ).
+    pub struct SpciMessageFlags: u16 {
+        /// Architected message payload.
+        const ARCHITECTED = 0b0000;
 
-pub const SPCI_MESSAGE_ARCHITECTED: usize = 0x0;
-pub const SPCI_MESSAGE_IMPDEF: u16 = 0x1;
-pub const SPCI_MESSAGE_IMPDEF_MASK: u16 = 0x1;
+        /// Implementation defined message payload.
+        const IMPDEF = 0b0001;
+    }
+}
 
-pub const SPCI_MSG_SEND_NOTIFY: u32 = 0x1;
-pub const SPCI_MSG_RECV_BLOCK: u32 = 0x1;
+bitflags! {
+    pub struct SpciMsgRecvAttributes: u32 {
+        const BLOCK = 0b0001;
+    }
+}
+
+bitflags! {
+    pub struct SpciMsgSendAttributes: u32 {
+        const NOTIFY = 0b0001;
+    }
+}
 
 /// The maximum length possible for a single message.
 pub const SPCI_MSG_PAYLOAD_MAX: usize = HF_MAILBOX_SIZE - mem::size_of::<SpciMessage>();
@@ -89,11 +103,7 @@ pub struct SpciMessage {
     // TODO: version is part of SPCI alpha2 but will be
     // removed in the next spec revision hence we are not
     // including it in the header.
-    /// flags[0]:
-    ///     0: Architected message payload;
-    ///     1: Implementation defined message payload.
-    /// flags[15:1] reserved (MBZ).
-    pub flags: u16,
+    pub flags: SpciMessageFlags,
 
     /// TODO: Padding is present to ensure controlled offset
     /// of the length field. SPCI spec must be updated

--- a/hfo2/src/spci.rs
+++ b/hfo2/src/spci.rs
@@ -25,15 +25,20 @@ pub const SPCI_VERSION_MAJOR: i32 = 0x0;
 pub const SPCI_VERSION_MINOR: i32 = 0x9;
 pub const SPCI_VERSION_MAJOR_OFFSET: usize = 16;
 
-// SPCI return codes.
-pub const SPCI_SUCCESS: i32 = 0;
-pub const SPCI_NOT_SUPPORTED: i32 = -1;
-pub const SPCI_INVALID_PARAMETERS: i32 = -2;
-pub const SPCI_NO_MEMORY: i32 = -3;
-pub const SPCI_BUSY: i32 = -4;
-pub const SPCI_INTERRUPTED: i32 = -5;
-pub const SPCI_DENIED: i32 = -6;
-pub const SPCI_RETRY: i32 = -7;
+/// Return type of SPCI functions.
+/// TODO: Reuse `SpciReturn` type on all SPCI functions declarations.
+#[repr(i32)]
+#[derive(PartialEq)]
+pub enum SpciReturn {
+    Success = 0,
+    NotSupported = -1,
+    InvalidParameters = -2,
+    NoMemory = -3,
+    Busy = -4,
+    Interrupted = -5,
+    Denied = -6,
+    Retry = -7,
+}
 
 /// Architected memory sharing message IDs.
 #[repr(C)]
@@ -63,7 +68,7 @@ extern "C" {
         architected_message_replica: *const SpciArchitectedMessageHeader,
         from_message_replica: *mut SpciMessage,
         to_msg: *mut SpciMessage,
-    ) -> spci_return_t;
+    ) -> SpciReturn;
 
     pub fn spci_msg_check_transition(
         to: *mut Vm,

--- a/hfo2/src/types.rs
+++ b/hfo2/src/types.rs
@@ -43,16 +43,19 @@ pub type spci_vcpu_index_t = u16;
 /// it a different name to make the different semantics clear.
 pub type spci_vcpu_count_t = spci_vcpu_index_t;
 
+/// The ID of a interrupt. (TODO: Is it better to be `spci_intid_t`?)
+pub type intid_t = u32;
+
 pub const RSIZE_MAX: rsize_t = rsize_t::max_value() >> 1;
 
 /// The number of virtual interrupt IDs which are supported.
-pub const HF_NUM_INTIDS: usize = 64;
+pub const HF_NUM_INTIDS: intid_t = 64;
 
 /// Interrupt ID returned when there is no interrupt pending.
-pub const HF_INVALID_INTID: u32 = 0xffffffff;
+pub const HF_INVALID_INTID: intid_t = 0xffffffff;
 
 /// The virtual interrupt ID used for the virtual timer.
-pub const HF_VIRTUAL_TIMER_INTID: u32 = 3;
+pub const HF_VIRTUAL_TIMER_INTID: intid_t = 3;
 
 // These constants are originally from build scripts. Fortunately most
 // testing environments have same conditions (MAX_CPUS=8, MAX_VMS=16.) And

--- a/hfo2/src/types.rs
+++ b/hfo2/src/types.rs
@@ -43,10 +43,6 @@ pub type spci_vcpu_index_t = u16;
 /// it a different name to make the different semantics clear.
 pub type spci_vcpu_count_t = spci_vcpu_index_t;
 
-/// Return type of SPCI functions.
-/// TODO: Reuse spci_return_t type on all SPCI functions declarations.
-pub type spci_return_t = i32;
-
 pub const RSIZE_MAX: rsize_t = rsize_t::max_value() >> 1;
 
 /// The number of virtual interrupt IDs which are supported.

--- a/inc/hf/api.h
+++ b/inc/hf/api.h
@@ -28,7 +28,7 @@ spci_vm_count_t api_vm_get_count(void);
 spci_vcpu_count_t api_vcpu_get_count(spci_vm_id_t vm_id,
 				     const struct vcpu *current);
 void api_regs_state_saved(struct vcpu *vcpu);
-struct hf_vcpu_run_return api_vcpu_run(spci_vm_id_t vm_id,
+uint64_t api_vcpu_run(spci_vm_id_t vm_id,
 				       spci_vcpu_index_t vcpu_idx,
 				       const struct vcpu *current,
 				       struct vcpu **next);

--- a/inc/vmapi/hf/abi.h
+++ b/inc/vmapi/hf/abi.h
@@ -122,6 +122,32 @@ enum hf_share {
 };
 
 /**
+ * Encode an hf_vcpu_run_return struct in the 64-bit packing ABI.
+ */
+static inline uint64_t hf_vcpu_run_return_encode(struct hf_vcpu_run_return res)
+{
+	uint64_t ret = res.code & 0xff;
+
+	switch (res.code) {
+	case HF_VCPU_RUN_WAKE_UP:
+		ret |= (uint64_t)res.wake_up.vm_id << 32;
+		ret |= (uint64_t)res.wake_up.vcpu << 16;
+		break;
+	case HF_VCPU_RUN_MESSAGE:
+		ret |= res.message.vm_id << 8;
+		break;
+	case HF_VCPU_RUN_WAIT_FOR_INTERRUPT:
+	case HF_VCPU_RUN_WAIT_FOR_MESSAGE:
+		ret |= res.sleep.ns << 8;
+		break;
+	default:
+		break;
+	}
+
+	return ret;
+}
+
+/**
  * Decode an hf_vcpu_run_return struct from the 64-bit packing ABI.
  */
 static inline struct hf_vcpu_run_return hf_vcpu_run_return_decode(uint64_t res)

--- a/inc/vmapi/hf/abi.h
+++ b/inc/vmapi/hf/abi.h
@@ -122,32 +122,6 @@ enum hf_share {
 };
 
 /**
- * Encode an hf_vcpu_run_return struct in the 64-bit packing ABI.
- */
-static inline uint64_t hf_vcpu_run_return_encode(struct hf_vcpu_run_return res)
-{
-	uint64_t ret = res.code & 0xff;
-
-	switch (res.code) {
-	case HF_VCPU_RUN_WAKE_UP:
-		ret |= (uint64_t)res.wake_up.vm_id << 32;
-		ret |= (uint64_t)res.wake_up.vcpu << 16;
-		break;
-	case HF_VCPU_RUN_MESSAGE:
-		ret |= res.message.vm_id << 8;
-		break;
-	case HF_VCPU_RUN_WAIT_FOR_INTERRUPT:
-	case HF_VCPU_RUN_WAIT_FOR_MESSAGE:
-		ret |= res.sleep.ns << 8;
-		break;
-	default:
-		break;
-	}
-
-	return ret;
-}
-
-/**
  * Decode an hf_vcpu_run_return struct from the 64-bit packing ABI.
  */
 static inline struct hf_vcpu_run_return hf_vcpu_run_return_decode(uint64_t res)

--- a/src/arch/aarch64/hypervisor/handler.c
+++ b/src/arch/aarch64/hypervisor/handler.c
@@ -294,8 +294,7 @@ struct hvc_handler_return hvc_handler(uintreg_t arg0, uintreg_t arg1,
 		break;
 
 	case HF_VCPU_RUN:
-		ret.user_ret = hf_vcpu_run_return_encode(
-			api_vcpu_run(arg1, arg2, current(), &ret.new));
+		ret.user_ret = api_vcpu_run(arg1, arg2, current(), &ret.new);
 		break;
 
 	case SPCI_YIELD_32:


### PR DESCRIPTION
(#13)의 작은 목표 여러 개를 해결합니다.
 - `SPCI_SUCCESS` 및 관련 상수를 enum으로 만듭니다.
 - `SPCI_MSG_RECV_*` 및 관련 상수를 bit flag로 만듭니다.
 - `{mm, api}.rs` 에서 `mm::Mode`를 씁니다.
 - `*_INTID` 값들에 대해 `intid_t` 타입을 줍니다.
 - `union` 이었던 `HfVCpuRunReturn` 을 `enum`으로 바꿉니다.
   - `hf_vcpu_run_return_encode` 함수를 바꾸고, 이 함수를 호출하는 딱 하나의 C 코드를 수정했습니다.
 - `mm.rs` 에서 `mm.c`에서 쓰던 관련 타입들을 쓰도록 합니다. (#8)
    - `*addr_t`, `ptable_addr_t`, `pte_t` 등.

Closes #13 