### PR TITLE
Make a safe version of FdtNode.

### DIFF
--- a/hfo2/src/fdt.rs
+++ b/hfo2/src/fdt.rs
@@ -456,13 +456,16 @@ pub unsafe extern "C" fn fdt_root_node(node: *mut fdt_node, hdr: *const FdtHeade
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn fdt_find_child(node: *mut fdt_node, child: *const u8) -> bool {
-    FdtNode::from((*node).clone()).find_child(child).is_some()
+pub unsafe extern "C" fn fdt_find_child(c_node: *mut fdt_node, child: *const u8) -> bool {
+    let mut node = FdtNode::from((*c_node).clone());
+    let ret = node.find_child(child).is_some();
+    ptr::write(c_node, node.into());
+    ret
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn fdt_read_property(
-    node: *mut fdt_node,
+    node: *const fdt_node,
     name: *const u8,
     buf: *mut *const u8,
     size: *mut u32,


### PR DESCRIPTION
 - `FdtNode`, `FdtTokenizer` 가 slice를 멤버로 가지고 있도록 바꿉니다.
 - C FFI 에 필요한 기존의 `FdtNode`는 `CFdtNode`로 이름을 바꿉니다.