### PR TITLE
Sink unsafe in FFIs

### DIFF
--- a/hfo2/src/api.rs
+++ b/hfo2/src/api.rs
@@ -222,10 +222,7 @@ pub extern "C" fn api_spci_msg_recv(
 #[no_mangle]
 pub extern "C" fn api_mailbox_writable_get(current: *const VCpu) -> i64 {
     let current = ManuallyDrop::new(unsafe { VCpuExecutionLocked::from_raw(current) });
-    let res = some_or!(
-        hypervisor().api_mailbox_writable_get(&current),
-        return -1
-    );
+    let res = some_or!(hypervisor().api_mailbox_writable_get(&current), return -1);
 
     i64::from(res)
 }

--- a/hfo2/src/cpu.rs
+++ b/hfo2/src/cpu.rs
@@ -443,8 +443,8 @@ impl CpuManager {
         *is_on = true;
 
         if !prev {
-            let vm = vm_manager.get(HF_PRIMARY_VM_ID).unwrap();
-            let vcpu = vm.vcpus.get(self.index_of(c)).unwrap();
+            let vm = vm_manager.get_primary();
+            let vcpu = &vm.vcpus[self.index_of(c)];
 
             vcpu.inner.lock().on(entry, arg);
         }
@@ -462,9 +462,8 @@ impl CpuManager {
         None
     }
 
-    /// Temporal impl (WIP)
-    pub fn boot_cpu(&self) -> *mut Cpu {
-        self.cpus.get(0).unwrap() as &Cpu as *const _ as usize as *mut _
+    pub fn get_boot_cpu(&self) -> &Cpu {
+        unsafe { self.cpus.get_unchecked(0) }
     }
 }
 

--- a/hfo2/src/dlog.rs
+++ b/hfo2/src/dlog.rs
@@ -59,21 +59,23 @@ pub fn _print(args: fmt::Arguments) {
 
 /// Enables the lock protecting the serial device.
 #[no_mangle]
-pub unsafe extern "C" fn dlog_enable_lock() {
+pub extern "C" fn dlog_enable_lock() {
     DLOG_LOCK_ENABLED.store(true, Ordering::Relaxed);
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dlog_lock() {
+pub extern "C" fn dlog_lock() {
     if DLOG_LOCK_ENABLED.load(Ordering::Relaxed) {
         mem::forget(WRITER.lock());
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dlog_unlock() {
+pub extern "C" fn dlog_unlock() {
     if DLOG_LOCK_ENABLED.load(Ordering::Relaxed) {
-        WRITER.unlock_unchecked();
+        unsafe {
+            WRITER.unlock_unchecked();
+        }
     }
 }
 

--- a/hfo2/src/dlog.rs
+++ b/hfo2/src/dlog.rs
@@ -16,7 +16,6 @@
 
 use core::fmt;
 use core::mem;
-use core::sync::atomic::{AtomicBool, Ordering};
 
 use crate::spinlock::*;
 
@@ -60,7 +59,9 @@ pub fn _print(args: fmt::Arguments) {
 /// Enables the lock protecting the serial device.
 #[no_mangle]
 pub extern "C" fn dlog_enable_lock() {
-    unsafe { DLOG_LOCK_ENABLED = true; }
+    unsafe {
+        DLOG_LOCK_ENABLED = true;
+    }
 }
 
 #[no_mangle]

--- a/hfo2/src/hypervisor.rs
+++ b/hfo2/src/hypervisor.rs
@@ -67,11 +67,8 @@ impl Hypervisor {
         mut primary_ret: HfVCpuRunReturn,
         secondary_state: VCpuStatus,
     ) -> &VCpu {
-        let primary = self.vm_manager.get(HF_PRIMARY_VM_ID).unwrap();
-        let next = primary
-            .vcpus
-            .get(self.cpu_manager.index_of(current.get_inner().cpu))
-            .unwrap();
+        let primary = self.vm_manager.get_primary();
+        let next = &primary.vcpus[self.cpu_manager.index_of(current.get_inner().cpu)];
 
         // If the secondary is blocked but has a timer running, sleep until the timer fires rather
         // than indefinitely.

--- a/hfo2/src/init.rs
+++ b/hfo2/src/init.rs
@@ -203,13 +203,14 @@ pub fn hypervisor() -> &'static Hypervisor {
 // all state and return the first vCPU to run.
 #[no_mangle]
 pub unsafe extern "C" fn cpu_main(c: *const Cpu) -> *const VCpu {
-    let raw_ptable = hypervisor()
-        .memory_manager
-        .get_raw_ptable();
+    let raw_ptable = hypervisor().memory_manager.get_raw_ptable();
     MemoryManager::cpu_init(raw_ptable).expect("mm_cpu_init failed");
 
     let primary = hypervisor().vm_manager.get(HF_PRIMARY_VM_ID).unwrap();
-    let vcpu = primary.vcpus.get(hypervisor().cpu_manager.index_of(c)).unwrap();
+    let vcpu = primary
+        .vcpus
+        .get(hypervisor().cpu_manager.index_of(c))
+        .unwrap();
     let vm = vcpu.vm;
 
     // TODO(HfO2): vcpu needs to be borrowed exclusively, which is safe but

--- a/hfo2/src/init.rs
+++ b/hfo2/src/init.rs
@@ -211,7 +211,7 @@ pub unsafe extern "C" fn cpu_main(c: *const Cpu) -> *const VCpu {
     mm_cpu_init(raw_ptable).expect("mm_cpu_init failed");
 
     let primary = hypervisor().vm_manager.get(HF_PRIMARY_VM_ID).unwrap();
-    let vcpu = primary.vcpus.get(cpu_index(&*c)).unwrap();
+    let vcpu = primary.vcpus.get(hypervisor().cpu_manager.index_of(c)).unwrap();
     let vm = vcpu.vm;
 
     // TODO(HfO2): vcpu needs to be borrowed exclusively, which is safe but

--- a/hfo2/src/init.rs
+++ b/hfo2/src/init.rs
@@ -205,9 +205,7 @@ pub fn hypervisor() -> &'static Hypervisor {
 pub unsafe extern "C" fn cpu_main(c: *const Cpu) -> *const VCpu {
     let raw_ptable = hypervisor()
         .memory_manager
-        .hypervisor_ptable
-        .get_mut_unchecked()
-        .get_raw();
+        .get_raw_ptable();
     mm_cpu_init(raw_ptable).expect("mm_cpu_init failed");
 
     let primary = hypervisor().vm_manager.get(HF_PRIMARY_VM_ID).unwrap();

--- a/hfo2/src/init.rs
+++ b/hfo2/src/init.rs
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn cpu_main(c: *const Cpu) -> *const VCpu {
     let raw_ptable = hypervisor()
         .memory_manager
         .get_raw_ptable();
-    mm_cpu_init(raw_ptable).expect("mm_cpu_init failed");
+    MemoryManager::cpu_init(raw_ptable).expect("mm_cpu_init failed");
 
     let primary = hypervisor().vm_manager.get(HF_PRIMARY_VM_ID).unwrap();
     let vcpu = primary.vcpus.get(hypervisor().cpu_manager.index_of(c)).unwrap();

--- a/hfo2/src/mm.rs
+++ b/hfo2/src/mm.rs
@@ -759,10 +759,6 @@ impl<S: Stage> PageTable<S> {
         }
     }
 
-    pub fn get_raw(&self) -> paddr_t {
-        self.root
-    }
-
     const unsafe fn null() -> Self {
         Self::from_raw(pa_init(0))
     }
@@ -1098,6 +1094,14 @@ impl MemoryManager {
             hypervisor_ptable: page_table,
             stage2_invalidate: AtomicBool::new(false),
         })
+    }
+
+    /// Returns the root address of the page table of the hypervisor. It is safe not to lock 
+    /// `self.inner` because the value of `ptable.as_raw()` doesn't change after `ptable` is 
+    /// initialized. Of course, actual page table may vary during running. That's why this function 
+    /// returns `paddr_t` rather than `&[RawPageTable]`.
+    pub fn get_raw_ptable(&self) -> paddr_t {
+        unsafe { self.hypervisor_ptable.get_unchecked().as_raw() }
     }
 }
 

--- a/hfo2/src/mm.rs
+++ b/hfo2/src/mm.rs
@@ -1096,9 +1096,9 @@ impl MemoryManager {
         })
     }
 
-    /// Returns the root address of the page table of the hypervisor. It is safe not to lock 
-    /// `self.inner` because the value of `ptable.as_raw()` doesn't change after `ptable` is 
-    /// initialized. Of course, actual page table may vary during running. That's why this function 
+    /// Returns the root address of the page table of the hypervisor. It is safe not to lock
+    /// `self.inner` because the value of `ptable.as_raw()` doesn't change after `ptable` is
+    /// initialized. Of course, actual page table may vary during running. That's why this function
     /// returns `paddr_t` rather than `&[RawPageTable]`.
     pub fn get_raw_ptable(&self) -> paddr_t {
         unsafe { self.hypervisor_ptable.get_unchecked().as_raw() }
@@ -1114,9 +1114,21 @@ impl MemoryManager {
 
     pub fn vm_unmap_hypervisor(ptable: &mut PageTable<Stage2>, mpool: &MPool) -> Result<(), ()> {
         // TODO: If we add pages dynamically, they must be included here too.
-        ptable.unmap(unsafe { layout_text_begin() } , unsafe { layout_text_end() }, mpool)?;
-        ptable.unmap(unsafe { layout_rodata_begin() }, unsafe { layout_rodata_end() }, mpool)?;
-        ptable.unmap(unsafe { layout_data_begin() }, unsafe { layout_data_end() }, mpool)?;
+        ptable.unmap(
+            unsafe { layout_text_begin() },
+            unsafe { layout_text_end() },
+            mpool,
+        )?;
+        ptable.unmap(
+            unsafe { layout_rodata_begin() },
+            unsafe { layout_rodata_end() },
+            mpool,
+        )?;
+        ptable.unmap(
+            unsafe { layout_data_begin() },
+            unsafe { layout_data_end() },
+            mpool,
+        )?;
 
         Ok(())
     }
@@ -1190,10 +1202,7 @@ pub unsafe extern "C" fn mm_vm_unmap(
 }
 
 #[no_mangle]
-pub extern "C" fn mm_vm_unmap_hypervisor(
-    t: *mut PageTable<Stage2>,
-    mpool: *const MPool,
-) -> bool {
+pub extern "C" fn mm_vm_unmap_hypervisor(t: *mut PageTable<Stage2>, mpool: *const MPool) -> bool {
     MemoryManager::vm_unmap_hypervisor(unsafe { &mut *t }, unsafe { &*mpool }).is_ok()
 }
 

--- a/hfo2/src/vm.rs
+++ b/hfo2/src/vm.rs
@@ -616,6 +616,11 @@ impl VmManager {
         self.vms.get_mut(id as usize)
     }
 
+    pub fn get_primary(&self) -> &Vm {
+        // Primary VM always exists.
+        unsafe { self.vms.get_unchecked(HF_PRIMARY_VM_ID as usize) }
+    }
+
     pub fn len(&self) -> spci_vm_count_t {
         self.vms.len() as _
     }

--- a/hfo2/src/vm.rs
+++ b/hfo2/src/vm.rs
@@ -624,22 +624,23 @@ impl VmManager {
 /// Get the vCPU with the given index from the given VM.
 /// This assumes the index is valid, i.e. less than vm->vcpu_count.
 #[no_mangle]
-pub unsafe extern "C" fn vm_get_vcpu(vm: *mut Vm, vcpu_index: spci_vcpu_index_t) -> *mut VCpu {
-    assert!((vcpu_index as usize) < (*vm).vcpus.len());
-    &mut (*vm).vcpus[vcpu_index as usize]
+pub extern "C" fn vm_get_vcpu(vm: *const Vm, vcpu_index: spci_vcpu_index_t) -> *const VCpu {
+    let vm = unsafe { &*vm };
+    assert!((vcpu_index as usize) < vm.vcpus.len());
+    &vm.vcpus[vcpu_index as usize]
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn vm_get_id(vm: *const Vm) -> spci_vm_id_t {
-    (*vm).id
+pub extern "C" fn vm_get_id(vm: *const Vm) -> spci_vm_id_t {
+    unsafe { (*vm).id }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn vm_get_arch(vm: *mut Vm) -> *mut ArchVm {
-    &mut (*vm).inner.get_mut_unchecked().arch
+pub extern "C" fn vm_get_arch(vm: *const Vm) -> *mut ArchVm {
+    unsafe { &mut (*vm).inner.get_mut_unchecked().arch }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn vm_get_vcpu_count(vm: *const Vm) -> spci_vcpu_count_t {
-    (*vm).vcpus.len() as _
+pub extern "C" fn vm_get_vcpu_count(vm: *const Vm) -> spci_vcpu_count_t {
+    unsafe { (*vm).vcpus.len() as _ }
 }

--- a/hfo2/src/vm.rs
+++ b/hfo2/src/vm.rs
@@ -522,7 +522,7 @@ impl Vm {
     /// lock `self.inner` because the value of `ptable.as_raw()` doesn't change
     /// after `ptable` is initialized. Of course, actual page table may vary
     /// during running. That's why this function returns `paddr_t` rather than
-    /// `&RawPage`.
+    /// `&[RawPageTable]`.
     pub fn get_ptable_raw(&self) -> paddr_t {
         unsafe { self.inner.get_unchecked().ptable.as_raw() }
     }


### PR DESCRIPTION
C2Rust 개발자들이 unsafe 함수에서 unsafe를 떼고 내부에 unsafe block을 넣는 것을 `sink`라고 말하더군요.
 - API, VM, MM, CPU 의 FFI 함수들에서 unsafe를 내부로 집어넣었습니다.
 - `PageTable`의 root address를 가져오는 safe wrapper를 통일하고 정리했습니다.
 - `slice::get().unwrap()` 을 정리했습니다.