### PR TITLE
Reduce small unsafe in mpool.rs; Rollback the implementation of alloc

### DIFF
--- a/hfo2/src/mpool.rs
+++ b/hfo2/src/mpool.rs
@@ -99,16 +99,12 @@ impl Pool {
 
         let chunk = unsafe { self.chunk_list.pop().ok_or(())? };
         let size = unsafe { (*chunk).size };
-        assert_ne!(size, 0);
+        debug_assert_ne!(size, 0);
+
         #[allow(clippy::cast_ptr_alignment)]
         let page = unsafe { Page::from_raw(chunk as *mut RawPage) };
 
-        if size == 2 {
-            let entry = unsafe { &mut *((chunk as usize + PAGE_SIZE) as *mut Entry) };
-            unsafe {
-                self.entry_list.push(entry);
-            }
-        } else if size > 2 {
+        if size > 1 {
             let new_chunk = unsafe { &mut *((chunk as usize + PAGE_SIZE) as *mut Chunk) };
             new_chunk.size = size - 1;
             unsafe { self.chunk_list.push(new_chunk) };

--- a/hfo2/src/slist.rs
+++ b/hfo2/src/slist.rs
@@ -19,7 +19,6 @@ use core::marker::PhantomData;
 use core::ptr;
 
 /// An entry in an intrusive linked list.
-#[derive(Debug)]
 #[repr(C)]
 pub struct ListEntry {
     /// The next entry in the linked list.
@@ -85,12 +84,11 @@ pub trait IsElement<T> {
     unsafe fn element_of(entry: &ListEntry) -> &T;
 }
 
-/// A lock-free, intrusive linked list of type `T`.
-#[derive(Debug)]
+/// A intrusive linked list of type `T`.
 #[repr(C)]
 pub struct List<T, C: IsElement<T> = T> {
     /// The head of the linked list.
-    pub(crate) head: ListEntry,
+    head: ListEntry,
 
     /// The phantom data for using `T` and `C`.
     _marker: PhantomData<(T, C)>,
@@ -110,7 +108,7 @@ impl ListEntry {
     /// You should guarantee that:
     ///
     /// - `container` is not null
-    /// - `container` is immovable, e.g. inside an `Owned`
+    /// - `container` is immovable, e.g. inside a `Page`
     /// - the same `ListEntry` is not inserted more than once
     /// - the inserted object will be removed before the list is dropped
     pub unsafe fn push<T, C: IsElement<T>>(&self, element: &T) {
@@ -143,7 +141,7 @@ impl<T, C: IsElement<T>> List<T, C> {
     /// You should guarantee that:
     ///
     /// - `container` is not null
-    /// - `container` is immovable, e.g. inside an `Owned`
+    /// - `container` is immovable, e.g. inside a `Page`
     /// - the same `ListEntry` is not inserted more than once
     /// - the inserted object will be removed before the list is dropped
     pub unsafe fn push(&mut self, element: &T) {

--- a/hfo2/src/slist.rs
+++ b/hfo2/src/slist.rs
@@ -148,15 +148,15 @@ impl<T, C: IsElement<T>> List<T, C> {
         self.head.push::<T, C>(element);
     }
 
-    pub unsafe fn pop(&mut self) -> Option<*mut T> {
+    pub fn pop(&mut self) -> Option<*mut T> {
         let head = self.head.next.get();
         if head.is_null() {
             return None;
         }
 
-        let next = (*head).next.get();
+        let next = unsafe { (*head).next.get() };
         self.head.next.set(next);
-        Some(C::element_of(&*head) as *const _ as *mut _)
+        Some(unsafe { C::element_of(&*head) } as *const _ as *mut _)
     }
 
     pub unsafe fn pop_if_some<R, F>(&mut self, cond: F) -> Option<(*mut T, R)>


### PR DESCRIPTION
 - `ListEntry::element_of` 는 unsafe일 필요가 없습니다 -- `List::pop`이 raw pointer를 리턴하므로.
 - `List::pop` 은 unsafe일 필요가 없습니다 -- `List::push` 가 unsafe이므로.
 - `Pool::alloc` 의 구현을 원래대로 바꿉니다.