### PR TITLE
Fix type bound of SpinLockGuard to be Send and Sync.

### DIFF
--- a/hfo2/src/spinlock.rs
+++ b/hfo2/src/spinlock.rs
@@ -144,8 +144,8 @@ pub struct SpinLockGuard<'s, T> {
     _marker: PhantomData<*const ()>, // !Send + !Sync
 }
 
-unsafe impl<'s, T> Send for SpinLockGuard<'s, T> {}
-unsafe impl<'s, T: Send + Sync> Sync for SpinLockGuard<'s, T> {}
+unsafe impl<'s, T: Send> Send for SpinLockGuard<'s, T> {}
+unsafe impl<'s, T: Sync> Sync for SpinLockGuard<'s, T> {}
 
 impl<'s, T> SpinLockGuard<'s, T> {
     pub fn raw(&mut self) -> usize {


### PR DESCRIPTION
Note. 일반적으로 `std::sync::MutexGuard` 는 `!Send`하지만, spinlock의 경우에는 락을 걸지 않은 thread가 락을 풀어도 문제가 없습니다.