### PR TITLE
Split vCPU lock

### DIFF
--- a/inc/hf/vcpu.h
+++ b/inc/hf/vcpu.h
@@ -31,9 +31,6 @@ enum vcpu_state {
 	/** The vCPU is ready to be run. */
 	VCPU_STATE_READY,
 
-	/** The vCPU is currently running. */
-	VCPU_STATE_RUNNING,
-
 	/** The vCPU is waiting for a message. */
 	VCPU_STATE_BLOCKED_MAILBOX,
 
@@ -65,7 +62,16 @@ struct vcpu_fault_info {
 };
 
 struct vcpu {
-	struct spinlock lock;
+	/*
+	 * Protects accesses to vCPU's state and architecture registers. If a
+	 * vCPU is running, its execution lock is logically held by the
+	 * running pCPU.
+	 */
+	struct spinlock execution_lock;
+	/*
+	 * Protects accesses to vCPU's interrupts.
+	 */
+	struct spinlock interrupts_lock;
 
 	/*
 	 * The state is only changed in the context of the vCPU being run. This
@@ -78,26 +84,19 @@ struct vcpu {
 	struct vm *vm;
 	struct arch_regs regs;
 	struct interrupts interrupts;
-
-	/*
-	 * Determine whether the 'regs' field is available for use. This is set
-	 * to false when a vCPU is about to run on a physical CPU, and is set
-	 * back to true when it is descheduled.
-	 */
-	bool regs_available;
 };
 
-/** Encapsulates a vCPU whose lock is held. */
-struct vcpu_locked {
+/** Encapsulates a vCPU whose execution lock is held. */
+struct vcpu_execution_locked {
 	struct vcpu *vcpu;
 };
 
-struct vcpu_locked vcpu_lock(struct vcpu *vcpu);
-void vcpu_unlock(struct vcpu_locked *locked);
+struct vcpu_execution_locked vcpu_lock(struct vcpu *vcpu);
+void vcpu_unlock(struct vcpu_execution_locked *locked);
 void vcpu_init(struct vcpu *vcpu, struct vm *vm);
-void vcpu_on(struct vcpu_locked vcpu, ipaddr_t entry, uintreg_t arg);
+void vcpu_on(struct vcpu_execution_locked vcpu, ipaddr_t entry, uintreg_t arg);
 spci_vcpu_index_t vcpu_index(const struct vcpu *vcpu);
-bool vcpu_is_off(struct vcpu_locked vcpu);
+bool vcpu_is_off(struct vcpu_execution_locked vcpu);
 bool vcpu_secondary_reset_and_start(struct vcpu *vcpu, ipaddr_t entry,
 				    uintreg_t arg);
 

--- a/src/arch/aarch64/hypervisor/handler.c
+++ b/src/arch/aarch64/hypervisor/handler.c
@@ -27,6 +27,7 @@
 #include "hf/dlog.h"
 #include "hf/panic.h"
 #include "hf/spci.h"
+#include "hf/spinlock.h"
 #include "hf/vm.h"
 
 #include "vmapi/hf/call.h"
@@ -388,20 +389,20 @@ static void update_vi(struct vcpu *next)
 		 */
 		struct vcpu *vcpu = current();
 
-		sl_lock(&vcpu->lock);
+		sl_lock(&vcpu->interrupts_lock);
 		set_virtual_interrupt_current(
 			vcpu->interrupts.enabled_and_pending_count > 0);
-		sl_unlock(&vcpu->lock);
+		sl_unlock(&vcpu->interrupts_lock);
 	} else {
 		/*
 		 * About to switch vCPUs, set the bit for the vCPU to which we
 		 * are switching in the saved copy of the register.
 		 */
-		sl_lock(&next->lock);
+		sl_lock(&next->interrupts_lock);
 		set_virtual_interrupt(
 			&next->regs,
 			next->interrupts.enabled_and_pending_count > 0);
-		sl_unlock(&next->lock);
+		sl_unlock(&next->interrupts_lock);
 	}
 }
 

--- a/src/arch/aarch64/hypervisor/psci_handler.c
+++ b/src/arch/aarch64/hypervisor/psci_handler.c
@@ -296,7 +296,7 @@ bool psci_secondary_vm_handler(struct vcpu *vcpu, uint32_t func, uintreg_t arg0,
 		cpu_id_t target_affinity = arg0;
 		uint32_t lowest_affinity_level = arg1;
 		struct vm *vm = vcpu->vm;
-		struct vcpu_locked target_vcpu;
+		struct vcpu_execution_locked target_vcpu;
 		spci_vcpu_index_t target_vcpu_index =
 			vcpu_id_to_index(target_affinity);
 

--- a/src/arch/aarch64/inc/hf/arch/spinlock.h
+++ b/src/arch/aarch64/inc/hf/arch/spinlock.h
@@ -29,6 +29,7 @@
  */
 
 #include <stdint.h>
+#include <stdatomic.h>
 
 #include "hf/arch/types.h"
 
@@ -59,6 +60,11 @@ static inline void sl_lock(struct spinlock *l)
 		: "+m"(*l), "=&r"(tmp1), "=&r"(tmp2)
 		: "r"(l)
 		: "cc");
+}
+
+static inline bool sl_try_lock(struct spinlock *l)
+{
+	return !atomic_flag_test_and_set_explicit((volatile atomic_flag *)&l->v, memory_order_acquire);
 }
 
 static inline void sl_unlock(struct spinlock *l)

--- a/src/arch/fake/inc/hf/arch/spinlock.h
+++ b/src/arch/fake/inc/hf/arch/spinlock.h
@@ -36,6 +36,11 @@ static inline void sl_lock(struct spinlock *l)
 	}
 }
 
+static inline bool sl_try_lock(struct spinlock *l)
+{
+	return !atomic_flag_test_and_set_explicit(&l->v, memory_order_acquire);
+}
+
 static inline void sl_unlock(struct spinlock *l)
 {
 	atomic_flag_clear_explicit(&l->v, memory_order_release);

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -141,11 +141,11 @@ bool cpu_on(struct cpu *c, ipaddr_t entry, uintreg_t arg)
 	if (!prev) {
 		struct vm *vm = vm_find(HF_PRIMARY_VM_ID);
 		struct vcpu *vcpu = vm_get_vcpu(vm, cpu_index(c));
-		struct vcpu_locked vcpu_locked;
+		struct vcpu_execution_locked vcpu_execution_locked;
 
-		vcpu_locked = vcpu_lock(vcpu);
-		vcpu_on(vcpu_locked, entry, arg);
-		vcpu_unlock(&vcpu_locked);
+		vcpu_execution_locked = vcpu_lock(vcpu);
+		vcpu_on(vcpu_execution_locked, entry, arg);
+		vcpu_unlock(&vcpu_execution_locked);
 	}
 
 	return prev;

--- a/src/load.c
+++ b/src/load.c
@@ -121,7 +121,7 @@ static bool load_primary(struct mm_stage1_locked stage1_locked,
 {
 	struct vm *vm;
 	struct vm_locked vm_locked;
-	struct vcpu_locked vcpu_locked;
+	struct vcpu_execution_locked vcpu_execution_locked;
 	size_t i;
 	bool ret;
 
@@ -218,9 +218,9 @@ static bool load_primary(struct mm_stage1_locked stage1_locked,
 	dlog_info("Loaded primary VM with %u vCPUs, entry at %#x.\n",
 		  vm->vcpu_count, pa_addr(primary_begin));
 
-	vcpu_locked = vcpu_lock(vm_get_vcpu(vm, 0));
-	vcpu_on(vcpu_locked, ipa_from_pa(primary_begin), params->kernel_arg);
-	vcpu_unlock(&vcpu_locked);
+	vcpu_execution_locked = vcpu_lock(vm_get_vcpu(vm, 0));
+	vcpu_on(vcpu_execution_locked, ipa_from_pa(primary_begin), params->kernel_arg);
+	vcpu_unlock(&vcpu_execution_locked);
 	ret = true;
 
 out:

--- a/src/vcpu.c
+++ b/src/vcpu.c
@@ -24,13 +24,13 @@
 /**
  * Locks the given vCPU and updates `locked` to hold the newly locked vCPU.
  */
-struct vcpu_locked vcpu_lock(struct vcpu *vcpu)
+struct vcpu_execution_locked vcpu_lock(struct vcpu *vcpu)
 {
-	struct vcpu_locked locked = {
+	struct vcpu_execution_locked locked = {
 		.vcpu = vcpu,
 	};
 
-	sl_lock(&vcpu->lock);
+	sl_lock(&vcpu->execution_lock);
 
 	return locked;
 }
@@ -39,26 +39,27 @@ struct vcpu_locked vcpu_lock(struct vcpu *vcpu)
  * Unlocks a vCPU previously locked with vpu_lock, and updates `locked` to
  * reflect the fact that the vCPU is no longer locked.
  */
-void vcpu_unlock(struct vcpu_locked *locked)
+void vcpu_unlock(struct vcpu_execution_locked *locked)
 {
-	sl_unlock(&locked->vcpu->lock);
+	sl_unlock(&locked->vcpu->execution_lock);
 	locked->vcpu = NULL;
 }
 
 void vcpu_init(struct vcpu *vcpu, struct vm *vm)
 {
 	memset_s(vcpu, sizeof(*vcpu), 0, sizeof(*vcpu));
-	sl_init(&vcpu->lock);
-	vcpu->regs_available = true;
+	sl_init(&vcpu->execution_lock);
+	sl_init(&vcpu->interrupts_lock);
 	vcpu->vm = vm;
 	vcpu->state = VCPU_STATE_OFF;
 }
 
 /**
  * Initialise the registers for the given vCPU and set the state to
- * VCPU_STATE_READY. The caller must hold the vCPU lock while calling this.
+ * VCPU_STATE_READY. The caller must hold the vCPU execution lock while calling
+ * this.
  */
-void vcpu_on(struct vcpu_locked vcpu, ipaddr_t entry, uintreg_t arg)
+void vcpu_on(struct vcpu_execution_locked vcpu, ipaddr_t entry, uintreg_t arg)
 {
 	arch_regs_set_pc_arg(&vcpu.vcpu->regs, entry, arg);
 	vcpu.vcpu->state = VCPU_STATE_READY;
@@ -77,13 +78,12 @@ spci_vcpu_index_t vcpu_index(const struct vcpu *vcpu)
  * turning vCPUs on and off. Note that aborted still counts as on in this
  * context.
  */
-bool vcpu_is_off(struct vcpu_locked vcpu)
+bool vcpu_is_off(struct vcpu_execution_locked vcpu)
 {
 	switch (vcpu.vcpu->state) {
 	case VCPU_STATE_OFF:
 		return true;
 	case VCPU_STATE_READY:
-	case VCPU_STATE_RUNNING:
 	case VCPU_STATE_BLOCKED_MAILBOX:
 	case VCPU_STATE_BLOCKED_INTERRUPT:
 	case VCPU_STATE_ABORTED:
@@ -107,14 +107,14 @@ bool vcpu_is_off(struct vcpu_locked vcpu)
 bool vcpu_secondary_reset_and_start(struct vcpu *vcpu, ipaddr_t entry,
 				    uintreg_t arg)
 {
-	struct vcpu_locked vcpu_locked;
+	struct vcpu_execution_locked vcpu_execution_locked;
 	struct vm *vm = vcpu->vm;
 	bool vcpu_was_off;
 
 	CHECK(vm->id != HF_PRIMARY_VM_ID);
 
-	vcpu_locked = vcpu_lock(vcpu);
-	vcpu_was_off = vcpu_is_off(vcpu_locked);
+	vcpu_execution_locked = vcpu_lock(vcpu);
+	vcpu_was_off = vcpu_is_off(vcpu_execution_locked);
 	if (vcpu_was_off) {
 		/*
 		 * Set vCPU registers to a clean state ready for boot. As this
@@ -123,9 +123,9 @@ bool vcpu_secondary_reset_and_start(struct vcpu *vcpu, ipaddr_t entry,
 		 * pCPU it is running on.
 		 */
 		arch_regs_reset(vcpu);
-		vcpu_on(vcpu_locked, entry, arg);
+		vcpu_on(vcpu_execution_locked, entry, arg);
 	}
-	vcpu_unlock(&vcpu_locked);
+	vcpu_unlock(&vcpu_execution_locked);
 
 	return vcpu_was_off;
 }


### PR DESCRIPTION
Split vCPU lock into an execution lock and interrupts lock, and remove `regs_available` and `VCPU_STATE_RUNNING`.

Change-Id: ???

---

TODO:
 - [ ] `sl_try_lock`을 `src/arch/aarch64/inc/hf/arch/spinlock.h` 파일의 다른 함수들처럼 만들어야 합니다. 해당하는 어셈블리를 몰라서 당장은 반영하기 어려운 패치일 듯 합니다.
 - [ ] 위의 수정을 하고 테스트를 통과하도록 고쳐야 합니다.

Additional Idea:
저번에 말씀드린 대로 `vcpu` 의 내부 상태는 다음과 같은 union으로 나타낼 수 있습니다.
```c
union {
  struct {
    struct cpu *cpu;
  } running;
  struct {
    enum vcpu_state state;
    struct arch_regs regs;
  } suspended;
}
```
그런데 사실 current vcpu가 어디서 돌고 있는지는 현재의 스택 포인터를 통해서 알 수 있으므로 `cpu` field 도 필요 없습니다. 