### PR TITLE
Separate the inner structure of mpool.

### DIFF
--- a/inc/hf/mpool.h
+++ b/inc/hf/mpool.h
@@ -21,11 +21,15 @@
 
 #include "hf/spinlock.h"
 
-struct mpool {
-	struct spinlock lock;
+struct mpool_inner {
 	size_t entry_size;
 	struct mpool_chunk *chunk_list;
 	struct mpool_entry *entry_list;
+};
+
+struct mpool {
+	struct spinlock lock;
+	struct mpool_inner inner;
 	struct mpool *fallback;
 };
 


### PR DESCRIPTION
Note:
 - 바뀐 코드에서는 `mpool_inner.entry_size` 와 `mpool.fallback` 이 락으로 보호되지 않습니다. 기존의 코드에서는 `mpool_inner.entry_size` 는 (필요 없이) 보호되었고 `mpool.fallback` 은 보호하는 코드가 있고 그렇지 않은 코드도 있었습니다.

TODO:
 - [ ] `mpool_inner_appends_to` 이름이 이상하고,
 - [ ] 이 함수 내에서 락을 사실 안 걸어도 되는데, C에서는 full ownership 개념이 없어서 그렇게 하는 게 올바른 리팩토링인지 잘 모르겠습니다.